### PR TITLE
New style classes in Python 2.x

### DIFF
--- a/firebirdsql/fbcore.py
+++ b/firebirdsql/fbcore.py
@@ -26,6 +26,8 @@ def b2i(b):
         return ord(b)
 
 if PYTHON_MAJOR_VER == 2:
+    __metaclass__ = type
+
     def bytes(byte_array):
         return ''.join(chr(c) for c in byte_array)
 

--- a/firebirdsql/wireprotocol.py
+++ b/firebirdsql/wireprotocol.py
@@ -17,6 +17,8 @@ from firebirdsql.consts import *
 DEBUG = False
 
 if sys.version_info[0] == 2:
+    __metaclass__ = type
+
     def bytes(byte_array):
         return ''.join([chr(c) for c in byte_array])
 


### PR DESCRIPTION
The **metaclass** = type trick makes all classes new style classes without resorting to subclass object.
