### PR TITLE
prevent socket inheritance on execve(2)

### DIFF
--- a/firebirdsql/fbcore.py
+++ b/firebirdsql/fbcore.py
@@ -692,10 +692,10 @@ class Connection(WireProtocol):
         self.isolation_level = ISOLATION_LEVEL_READ_COMMITED
 
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        self.sock.connect((self.hostname, self.port))
         if cloexec:
             setcloexec(self.sock)
+        self.sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        self.sock.connect((self.hostname, self.port))
 
         self.page_size = page_size
         self.is_services = is_services


### PR DESCRIPTION
I've added a new option to Connection that sets the FD_CLOEXEC flag on the socket's file descriptor to prevent inheritance of FDs to child processes (POSIX only). The Firebird client lib doesn't have the feature and I had to through several loops to close FDs.

The pull request also has a fix for hostname on POSIX.
