### PR TITLE
printing error instead of opcode assertion

### DIFF
--- a/firebirdsql/wireprotocol.py
+++ b/firebirdsql/wireprotocol.py
@@ -475,6 +475,7 @@ class WireProtocol(object):
     @wire_operation
     def _op_accept(self):
         b = self.recv_channel(4)
+        error_message = b
         while bytes_to_bint(b) == self.op_dummy:
             b = self.recv_channel(4)
         if bytes_to_bint(b) == self.op_reject:
@@ -544,6 +545,10 @@ class WireProtocol(object):
                 else:   # use later _op_attach() and _op_create()
                     self.auth_data = auth_data
         else:
+            error_message += b
+            b = self.recv_channel(30)
+            error_message +=b
+            print(error_message)
             assert op_code == self.op_accept
 
     @wire_operation


### PR DESCRIPTION
For example

(3.6Firebird) F:\Yandex\Sites\backupScripts>c:\Python35\python.exe
tmp.py
b'Shared object "libstdc++.so.6" not found, requ'
Traceback (most recent call last):
File "tmp.py", line 22, in <module>
con=firebirdsql.connect(dsn=ip+dsn, user='sysdba',
password='masterkey',charset='WIN1251')
File "F:\TEMP\firebirdsql\pyfirebirdsql\firebirdsql\__init__.py", line
93, in connect
return Connection(**kwargs)
File "F:\TEMP\firebirdsql\pyfirebirdsql\firebirdsql\fbcore.py", line
619, in __init__
self._op_accept()
File "F:\TEMP\firebirdsql\pyfirebirdsql\firebirdsql\wireprotocol.py",
line 552, in _op_accept
assert op_code == self.op_accept
AssertionError