### PR TITLE
FIXME: python3-specific patch

### DIFF
--- a/firebirdsql/utils.py
+++ b/firebirdsql/utils.py
@@ -54,6 +54,9 @@ def bytes_to_hex(b):
     """
     convert bytes to hex string
     """
+    if isinstance(b, str):
+        b = bytes(b, 'utf-8')
+
     s = binascii.b2a_hex(b)
 
     return s


### PR DESCRIPTION
May not work with python2.6+
Description: *sometimes* executing cursor fails with error: type 'str' has not buffer interface
I assume unconverted values bound with login