### PR TITLE
fix - pypy 7.3 encoding() fails for bytes - check for unicode under pypy

### DIFF
--- a/firebirdsql/wireprotocol.py
+++ b/firebirdsql/wireprotocol.py
@@ -230,7 +230,7 @@ class WireProtocol(object):
 
     def str_to_bytes(self, s):
         "convert str to bytes"
-        if (PYTHON_MAJOR_VER == 3 or
+        if ((PYTHON_MAJOR_VER == 3  and isinstance(s,str)) or
                 (PYTHON_MAJOR_VER == 2 and type(s) == unicode)):
             return s.encode(charset_map.get(self.charset, self.charset))
         return s
@@ -410,7 +410,7 @@ class WireProtocol(object):
                 blr += bs([23])
             else:   # fallback, convert to string
                 p = p.__repr__()
-                if PYTHON_MAJOR_VER == 3 or (PYTHON_MAJOR_VER == 2 and type(p) == unicode):
+                if (PYTHON_MAJOR_VER == 3 and isinstance(p, str)) or (PYTHON_MAJOR_VER == 2 and type(p) == unicode):
                     p = self.str_to_bytes(p)
                 v = p
                 nbytes = len(v)


### PR DESCRIPTION

python --version
Python 3.7.4 (87875bf2dfd8, Sep 24 2020, 07:26:36)
[PyPy 7.3.2-alpha0 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)]

#using example script from README
python ./test_firebirdsql.py Traceback (most recent call last):
 File "./test_firebirdsql.py", line 8, in <module>
   password='xxx'
 File "/opt/pypy/site-packages/firebirdsql/__init__.py", line 96, in connect
   conn = Connection(**kwargs)
 File "/opt/pypy/site-packages/firebirdsql/fbcore.py", line 630, in __init__
   self._op_attach()
 File "/opt/pypy/site-packages/firebirdsql/wireprotocol.py", line 663, in _op_attach
   enc_pass = self.str_to_bytes(enc_pass)
 File "/opt/pypy/site-packages/firebirdsql/wireprotocol.py", line 236, in str_to_bytes
   return s.encode(charset_map.get(self.charset, self.charset))
AttributeError: 'bytes' object has no attribute 'encode'