### PR TITLE
support hostname style from sqlalchemy

### DIFF
--- a/firebirdsql/compat.py
+++ b/firebirdsql/compat.py
@@ -1,0 +1,6 @@
+import sys
+import firebirdsql
+
+
+def register():
+    sys.modules['fdb'] = firebirdsql

--- a/firebirdsql/fbcore.py
+++ b/firebirdsql/fbcore.py
@@ -574,6 +574,8 @@ class Connection(WireProtocol):
         WireProtocol.__init__(self)
         self.sock = None
         self.db_handle = None
+        if '/' in host:
+            host = host[0:host.find('/')]
         if dsn:
             i = dsn.find(':')
             if i < 0:


### PR DESCRIPTION
sqlalchemy  fdb dialact have their own style for host (host/port)
https://github.com/pauldex/sqlalchemy-firebird/blob/71f338226282cc854b11e4dee3be6d75be2fdc63/sqlalchemy_firebird/fdb.py#L83
if we support this style, it will be easy to add support for sqlalchemy