### PR TITLE
support hostname style from sqlalchemy and compatility layer

### DIFF
--- a/firebirdsql/compat.py
+++ b/firebirdsql/compat.py
@@ -1,0 +1,6 @@
+import sys
+import firebirdsql
+
+
+def register():
+    sys.modules['fdb'] = firebirdsql

--- a/firebirdsql/fbcore.py
+++ b/firebirdsql/fbcore.py
@@ -574,6 +574,8 @@ class Connection(WireProtocol):
         WireProtocol.__init__(self)
         self.sock = None
         self.db_handle = None
+        if '/' in host:
+            host = host[0:host.find('/')]
         if dsn:
             i = dsn.find(':')
             if i < 0:


### PR DESCRIPTION
thank you for this awesome repos, and fast response

**summary** 
this commit make firebirdsql driver work with sqlalchemy by support sqlalchemy hostname style and add compatibility layer to make 'firebirdsql' look like 'fdb'

the first commit is sqlalchemy fdb dialact have their own style for host (host/port)
https://github.com/pauldex/sqlalchemy-firebird/blob/71f338226282cc854b11e4dee3be6d75be2fdc63/sqlalchemy_firebird/fdb.py#L83
if we support this style, it will be easy to add support for sqlalchemy

the second commit is ad compatibility layer for fdb
this commit can subtitude  'fdb' original driver to use 'firebirdsql' using this style  
https://github.com/svpcom/psycopg2cffi#readme:~:text=from%20psycopg2cffi%20import%20compat,compat.register()

use case is if end user use firebirdsql  and run  firebirdsql.registry()
this will subtitube 'fdb' driver and  commit 'support hostname style from sqlalchemy' will make this repo compatible with
sqlalchemy argument.
so, user can use firebirdsql driver  directly after add  .registry() no need to change  sqlalchemy code at all


