### PR TITLE
Add `passlib` as an extra requirement for `windows` platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,4 +48,9 @@ setup(
     author_email='nakagami@gmail.com',
     packages=['firebirdsql'],
     cmdclass=cmdclass,
+    extras_require={
+        ':sys_platform == "win32"': [
+            'passlib',
+        ],
+    },
 )


### PR DESCRIPTION
## Description

Modify `setup.py` to include `passlib` in the `extras_require` parameter. 

This change is necessary to ensure that `firebirdsql` has `passlib` dependency when installed on a `windows` system. It does not affect installations on other platforms, as `passlib` is ignored in those cases.

## Additional context

ref: https://github.com/nakagami/pyfirebirdsql/issues/99, https://github.com/nakagami/pyfirebirdsql/issues/104
