### PR TITLE
Add wire compression support for protocol version over 13

### DIFF
--- a/firebirdsql/stream.py
+++ b/firebirdsql/stream.py
@@ -56,6 +56,9 @@ class SocketStream(object):
         self._recv_buf = b''
 
     def enable_compression(self):
+        """Enable zlib wire compression for the stream.
+        Called after the server accepts compression during protocol negotiation.
+        """
         self._compressor = zlib.compressobj()
         self._decompressor = zlib.decompressobj()
         self._recv_buf = b''

--- a/firebirdsql/stream.py
+++ b/firebirdsql/stream.py
@@ -26,6 +26,7 @@
 # Python DB-API 2.0 module for Firebird.
 ##############################################################################
 import socket
+import zlib
 
 try:
     import fcntl
@@ -50,14 +51,36 @@ class SocketStream(object):
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         self.read_translator = None
         self.write_translator = None
+        self._compressor = None
+        self._decompressor = None
+        self._recv_buf = b''
+
+    def enable_compression(self):
+        self._compressor = zlib.compressobj()
+        self._decompressor = zlib.decompressobj()
+        self._recv_buf = b''
 
     def recv(self, nbytes):
-        b = self._sock.recv(nbytes)
-        if self.read_translator:
-            b = self.read_translator.decrypt(b)
-        return b
+        if self._decompressor:
+            while len(self._recv_buf) < nbytes:
+                b = self._sock.recv(max(nbytes, 8192))
+                if not b:
+                    break
+                if self.read_translator:
+                    b = self.read_translator.decrypt(b)
+                self._recv_buf += self._decompressor.decompress(b)
+            result = self._recv_buf[:nbytes]
+            self._recv_buf = self._recv_buf[nbytes:]
+            return result
+        else:
+            b = self._sock.recv(nbytes)
+            if self.read_translator:
+                b = self.read_translator.decrypt(b)
+            return b
 
     def send(self, b):
+        if self._compressor:
+            b = self._compressor.compress(b) + self._compressor.flush(zlib.Z_SYNC_FLUSH)
         if self.write_translator:
             b = self.write_translator.encrypt(b)
         n = 0

--- a/firebirdsql/tests/test_compression.py
+++ b/firebirdsql/tests/test_compression.py
@@ -34,7 +34,7 @@ class TestCompressionStream(unittest.TestCase):
 
     def test_compression_with_encryption(self):
         """Test that compression + encryption layering works correctly.
-        Order: compress -> encrypt -> decrypt -> decompress"""
+        Send order: compress -> encrypt. Receive order: decrypt -> decompress."""
         from firebirdsql.arc4 import ARC4
 
         compressor = zlib.compressobj()

--- a/firebirdsql/tests/test_compression.py
+++ b/firebirdsql/tests/test_compression.py
@@ -1,0 +1,93 @@
+import unittest
+import zlib
+from unittest.mock import MagicMock, patch
+from firebirdsql.stream import SocketStream
+from firebirdsql.consts import pflag_compress, ptype_MASK, ptype_lazy_send
+
+
+class TestCompressionStream(unittest.TestCase):
+    """Test zlib compression/decompression in SocketStream."""
+
+    def test_roundtrip_compression(self):
+        """Test that data compressed by compressor can be decompressed by decompressor."""
+        compressor = zlib.compressobj()
+        decompressor = zlib.decompressobj()
+
+        original = b'Hello, Firebird wire protocol compression!'
+        compressed = compressor.compress(original) + compressor.flush(zlib.Z_SYNC_FLUSH)
+        decompressed = decompressor.decompress(compressed)
+        self.assertEqual(decompressed, original)
+
+    def test_streaming_compression(self):
+        """Test that streaming compression works across multiple messages."""
+        compressor = zlib.compressobj()
+        decompressor = zlib.decompressobj()
+
+        messages = [b'first message', b'second message', b'third message with more data']
+        recovered = []
+        for msg in messages:
+            compressed = compressor.compress(msg) + compressor.flush(zlib.Z_SYNC_FLUSH)
+            decompressed = decompressor.decompress(compressed)
+            recovered.append(decompressed)
+
+        self.assertEqual(recovered, messages)
+
+    def test_compression_with_encryption(self):
+        """Test that compression + encryption layering works correctly.
+        Order: compress -> encrypt -> decrypt -> decompress"""
+        from firebirdsql.arc4 import ARC4
+
+        compressor = zlib.compressobj()
+        decompressor = zlib.decompressobj()
+        enc = ARC4.new(b'test_key')
+        dec = ARC4.new(b'test_key')
+
+        original = b'Test data for compress+encrypt round-trip'
+        # Compress then encrypt
+        compressed = compressor.compress(original) + compressor.flush(zlib.Z_SYNC_FLUSH)
+        encrypted = enc.translate(compressed)
+        # Decrypt then decompress
+        decrypted = dec.translate(encrypted)
+        decompressed = decompressor.decompress(decrypted)
+        self.assertEqual(decompressed, original)
+
+    def test_pflag_compress_detection(self):
+        """Test that pflag_compress flag is correctly detected and stripped."""
+        accept_type = ptype_lazy_send | pflag_compress  # 5 | 0x100 = 0x105
+        self.assertTrue(accept_type & pflag_compress)
+        stripped = accept_type & ptype_MASK
+        self.assertEqual(stripped, ptype_lazy_send)
+
+    def test_pflag_compress_not_set(self):
+        """Test that missing pflag_compress is correctly detected."""
+        accept_type = ptype_lazy_send  # 5
+        self.assertFalse(accept_type & pflag_compress)
+
+    def test_enable_compression_sets_compressor(self):
+        """Test that enable_compression initializes zlib objects."""
+        with patch('socket.create_connection') as mock_conn:
+            mock_sock = MagicMock()
+            mock_conn.return_value = mock_sock
+            stream = SocketStream('localhost', 3050)
+            self.assertIsNone(stream._compressor)
+            self.assertIsNone(stream._decompressor)
+            stream.enable_compression()
+            self.assertIsNotNone(stream._compressor)
+            self.assertIsNotNone(stream._decompressor)
+
+    def test_large_data_compression(self):
+        """Test compression with larger data payloads."""
+        compressor = zlib.compressobj()
+        decompressor = zlib.decompressobj()
+
+        # Simulate a large query result
+        original = b'A' * 100000
+        compressed = compressor.compress(original) + compressor.flush(zlib.Z_SYNC_FLUSH)
+        # Compressed size should be significantly smaller for repetitive data
+        self.assertLess(len(compressed), len(original))
+        decompressed = decompressor.decompress(compressed)
+        self.assertEqual(decompressed, original)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/firebirdsql/wireprotocol.py
+++ b/firebirdsql/wireprotocol.py
@@ -365,7 +365,7 @@ class WireProtocol(object):
         return r
 
     @wire_operation
-    def _op_connect(self, auth_plugin_name, wire_crypt):
+    def _op_connect(self, auth_plugin_name, wire_crypt, wire_compress=False):
         protocols = [
             # PROTOCOL_VERSION, Arch type (Generic=1), min, max, weight
             '0000000a00000001000000000000000500000002',     # 10, 1, 0, 5, 2
@@ -377,6 +377,19 @@ class WireProtocol(object):
             'ffff80100000000100000000000000050000000e',     # 16, 1, 0, 5, 14
             'ffff801100000001000000000000000500000010',     # 17, 1, 0, 5, 16
         ]
+        if wire_compress:
+            protocols_with_compress = [
+                # PROTOCOL_VERSION, Arch type (Generic=1), min, max|pflag_compress, weight
+                '0000000a00000001000000000000000500000002',     # 10, 1, 0, 5, 2
+                'ffff800b00000001000000000000000500000004',     # 11, 1, 0, 5, 4
+                'ffff800c00000001000000000000000500000006',     # 12, 1, 0, 5, 6
+                'ffff800d00000001000000000000010500000008',     # 13, 1, 0, 0x105, 8
+                'ffff800e0000000100000000000001050000000a',     # 14, 1, 0, 0x105, 10
+                'ffff800f0000000100000000000001050000000c',     # 15, 1, 0, 0x105, 12
+                'ffff80100000000100000000000001050000000e',     # 16, 1, 0, 0x105, 14
+                'ffff801100000001000000000000010500000010',     # 17, 1, 0, 0x105, 16
+            ]
+            protocols = protocols_with_compress
         p = Packer()
         p.pack_int(self.op_connect)
         p.pack_int(self.op_attach)


### PR DESCRIPTION
Implements Firebird wire protocol compression using zlib, matching Jaybird's approach. Compression is opt-in via `wire_compress` parameter, negotiated via `pflag_compress` (0x100) flag during protocol handshake for versions ≥ 13.

### Changes

- **`stream.py` / `aio/stream.py`**: Added `enable_compression()` to `SocketStream` and `AsyncSocketStream`. Send path compresses with `Z_SYNC_FLUSH` before encryption; receive path decrypts then decompresses into a read buffer (compressed frame sizes ≠ decompressed sizes, so buffering is required).
- **`wireprotocol.py`**: `_op_connect` sets `pflag_compress` on the max-type field for protocol offers ≥ 13 when `wire_compress=True`.
- **`fbcore.py` / `aio/fbcore.py`**: Detects `pflag_compress` in server accept response, enables compression on socket, strips flag from `accept_type`. New `wire_compress=False` kwarg on `ConnectionBase.__init__`.

### Data flow

```
send: raw → zlib.compress + Z_SYNC_FLUSH → encrypt → socket
recv: socket → decrypt → zlib.decompress → buffer → read(n)
```

### Usage

```python
conn = firebirdsql.connect(
    host='localhost', database='test.fdb',
    user='sysdba', password='masterkey',
    wire_compress=True
)
```


