### PR TITLE
drop the mutable default in __init__

### DIFF
--- a/firebirdsql/err.py
+++ b/firebirdsql/err.py
@@ -30,7 +30,9 @@ class Warning(Exception):
 
 
 class Error(Exception):
-    def __init__(self, message, gds_codes=set(), sql_code=0):
+    def __init__(self, message, gds_codes=None, sql_code=0):
+        if gds_codes is None:
+            gds_codes = set()
         self._message = message
         self.gds_codes = gds_codes
         self.sql_code = sql_code


### PR DESCRIPTION
I ran into this while reading through the code path around firebirdsql/err.py. Drop the mutable default in __init__. Mutable defaults are shared across calls and usually turn into state leaks. I kept the patch small and re-ran syntax checks after applying it.