### PR TITLE
Let DB-API arraysize influence the actual fetch count

### DIFF
--- a/firebirdsql/aio/fbcore.py
+++ b/firebirdsql/aio/fbcore.py
@@ -83,7 +83,7 @@ class AsyncStatement(Statement):
             self.handle = h
         return self
 
-    async def fetch_generator(self, rows, more_data):
+    async def fetch_generator(self, rows, more_data, fetch_count=DEFAULT_FETCH_COUNT):
         DEBUG_OUTPUT("AsyncStatement::_fetch_generator()", self.handle, self.trans._trans_handle, self.trans.connection.db_handle)
         connection = self.trans.connection
         while rows:
@@ -119,7 +119,7 @@ class AsyncStatement(Statement):
                             r[i] = connection.bytes_to_str(r[i])
                 yield tuple(r)
             if more_data:
-                connection._op_fetch(self.handle, calc_blr(self.xsqlda))
+                connection._op_fetch(self.handle, calc_blr(self.xsqlda), fetch_count)
                 (rows, more_data) = await connection._async_op_fetch_response(self.handle, self.xsqlda)
             else:
                 break
@@ -257,9 +257,10 @@ class AsyncCursor(Cursor):
             (h, oid, buf) = await self.transaction.connection._async_op_response()
 
             if stmt.stmt_type == isc_info_sql_stmt_select:
-                self.transaction.connection._op_fetch(stmt.handle, calc_blr(stmt.xsqlda))
+                fetch_count = self._fetch_count()
+                self.transaction.connection._op_fetch(stmt.handle, calc_blr(stmt.xsqlda), fetch_count)
                 (rows, more_data) = await self.transaction.connection._async_op_fetch_response(stmt.handle, stmt.xsqlda)
-                self._fetch_records = stmt.fetch_generator(rows, more_data)
+                self._fetch_records = stmt.fetch_generator(rows, more_data, fetch_count)
             else:
                 self._fetch_records = None
             self._callproc_result = None

--- a/firebirdsql/aio/fbcore.py
+++ b/firebirdsql/aio/fbcore.py
@@ -83,7 +83,7 @@ class AsyncStatement(Statement):
             self.handle = h
         return self
 
-    async def fetch_generator(self, rows, more_data, fetch_count=DEFAULT_FETCH_COUNT):
+    async def fetch_generator(self, rows, more_data):
         DEBUG_OUTPUT("AsyncStatement::_fetch_generator()", self.handle, self.trans._trans_handle, self.trans.connection.db_handle)
         connection = self.trans.connection
         while rows:
@@ -119,7 +119,7 @@ class AsyncStatement(Statement):
                             r[i] = connection.bytes_to_str(r[i])
                 yield tuple(r)
             if more_data:
-                connection._op_fetch(self.handle, calc_blr(self.xsqlda), fetch_count)
+                connection._op_fetch(self.handle, calc_blr(self.xsqlda), max(self.arraysize, DEFAULT_FETCH_COUNT)
                 (rows, more_data) = await connection._async_op_fetch_response(self.handle, self.xsqlda)
             else:
                 break

--- a/firebirdsql/aio/fbcore.py
+++ b/firebirdsql/aio/fbcore.py
@@ -119,7 +119,7 @@ class AsyncStatement(Statement):
                             r[i] = connection.bytes_to_str(r[i])
                 yield tuple(r)
             if more_data:
-                connection._op_fetch(self.handle, calc_blr(self.xsqlda), max(self.arraysize, DEFAULT_FETCH_COUNT)
+                connection._op_fetch(self.handle, calc_blr(self.xsqlda), max(self.arraysize, DEFAULT_FETCH_COUNT))
                 (rows, more_data) = await connection._async_op_fetch_response(self.handle, self.xsqlda)
             else:
                 break

--- a/firebirdsql/aio/fbcore.py
+++ b/firebirdsql/aio/fbcore.py
@@ -83,7 +83,7 @@ class AsyncStatement(Statement):
             self.handle = h
         return self
 
-    async def fetch_generator(self, rows, more_data):
+    async def fetch_generator(self, rows, more_data, fetch_count):
         DEBUG_OUTPUT("AsyncStatement::_fetch_generator()", self.handle, self.trans._trans_handle, self.trans.connection.db_handle)
         connection = self.trans.connection
         while rows:
@@ -119,7 +119,7 @@ class AsyncStatement(Statement):
                             r[i] = connection.bytes_to_str(r[i])
                 yield tuple(r)
             if more_data:
-                connection._op_fetch(self.handle, calc_blr(self.xsqlda), max(self.arraysize, DEFAULT_FETCH_COUNT))
+                connection._op_fetch(self.handle, calc_blr(self.xsqlda), fetch_count)
                 (rows, more_data) = await connection._async_op_fetch_response(self.handle, self.xsqlda)
             else:
                 break
@@ -257,7 +257,7 @@ class AsyncCursor(Cursor):
             (h, oid, buf) = await self.transaction.connection._async_op_response()
 
             if stmt.stmt_type == isc_info_sql_stmt_select:
-                fetch_count = self._fetch_count()
+                fetch_count = max(self.arraysize, DEFAULT_FETCH_COUNT)
                 self.transaction.connection._op_fetch(stmt.handle, calc_blr(stmt.xsqlda), fetch_count)
                 (rows, more_data) = await self.transaction.connection._async_op_fetch_response(stmt.handle, stmt.xsqlda)
                 self._fetch_records = stmt.fetch_generator(rows, more_data, fetch_count)

--- a/firebirdsql/consts.py
+++ b/firebirdsql/consts.py
@@ -31,6 +31,11 @@ ISC_TIME_SECONDS_PRECISION = 10000
 MAX_CHAR_LENGTH = 32767
 BLOB_SEGMENT_SIZE = 32000
 
+# Number of rows requested from the server per op_fetch roundtrip.
+# Used as the lower bound when a cursor's arraysize is smaller, so the
+# DB-API default (arraysize == 1) keeps its historical batching behaviour.
+DEFAULT_FETCH_COUNT = 400
+
 DESCRIPTION_NAME = 0
 DESCRIPTION_TYPE_CODE = 1
 DESCRIPTION_DISPLAY_SIZE = 2

--- a/firebirdsql/fbcore.py
+++ b/firebirdsql/fbcore.py
@@ -70,7 +70,7 @@ class Statement(object):
         self._is_open = False
         self.stmt_type = None
 
-    def fetch_generator(self, rows, more_data):
+    def fetch_generator(self, rows, more_data, fetch_count):
         DEBUG_OUTPUT("Statement::_fetch_generator()", self.handle, self.trans._trans_handle, self.trans.connection.db_handle)
         connection = self.trans.connection
         while rows:
@@ -106,7 +106,7 @@ class Statement(object):
                             r[i] = connection.bytes_to_str(r[i])
                 yield tuple(r)
             if more_data:
-                connection._op_fetch(self.handle, calc_blr(self.xsqlda), max(self.arraysize, DEFAULT_FETCH_COUNT))
+                connection._op_fetch(self.handle, calc_blr(self.xsqlda), fetch_count)
                 (rows, more_data) = connection._op_fetch_response(self.handle, self.xsqlda)
             else:
                 break

--- a/firebirdsql/fbcore.py
+++ b/firebirdsql/fbcore.py
@@ -70,7 +70,7 @@ class Statement(object):
         self._is_open = False
         self.stmt_type = None
 
-    def fetch_generator(self, rows, more_data, fetch_count=DEFAULT_FETCH_COUNT):
+    def fetch_generator(self, rows, more_data):
         DEBUG_OUTPUT("Statement::_fetch_generator()", self.handle, self.trans._trans_handle, self.trans.connection.db_handle)
         connection = self.trans.connection
         while rows:
@@ -106,7 +106,7 @@ class Statement(object):
                             r[i] = connection.bytes_to_str(r[i])
                 yield tuple(r)
             if more_data:
-                connection._op_fetch(self.handle, calc_blr(self.xsqlda), fetch_count)
+                connection._op_fetch(self.handle, calc_blr(self.xsqlda), max(self.arraysize, DEFAULT_FETCH_COUNT))
                 (rows, more_data) = connection._op_fetch_response(self.handle, self.xsqlda)
             else:
                 break
@@ -269,7 +269,7 @@ class Cursor(object):
             (h, oid, buf) = self.transaction.connection._op_response()
 
             if stmt.stmt_type == isc_info_sql_stmt_select:
-                fetch_count = self._fetch_count()
+                fetch_count = max(self.arraysize, DEFAULT_FETCH_COUNT)
                 self.transaction.connection._op_fetch(stmt.handle, calc_blr(stmt.xsqlda), fetch_count)
                 (rows, more_data) = self.transaction.connection._op_fetch_response(stmt.handle, stmt.xsqlda)
                 self._fetch_records = stmt.fetch_generator(rows, more_data, fetch_count)
@@ -278,19 +278,6 @@ class Cursor(object):
             self._callproc_result = None
 
         return self
-
-    def _fetch_count(self):
-        """Rows to request per server roundtrip.
-
-        Honour cursor.arraysize (PEP 249) as a hint to reduce roundtrips, but
-        never drop below DEFAULT_FETCH_COUNT so the default arraysize of 1 keeps
-        its historical batching instead of fetching a single row at a time.
-        """
-        try:
-            arraysize = int(self.arraysize)
-        except (TypeError, ValueError):
-            arraysize = 0
-        return max(arraysize, DEFAULT_FETCH_COUNT)
 
     def _is_execute_procedure_query(self):
         """Return True if the current query is EXECUTE PROCEDURE / EXECUTE BLOCK."""

--- a/firebirdsql/fbcore.py
+++ b/firebirdsql/fbcore.py
@@ -70,7 +70,7 @@ class Statement(object):
         self._is_open = False
         self.stmt_type = None
 
-    def fetch_generator(self, rows, more_data):
+    def fetch_generator(self, rows, more_data, fetch_count=DEFAULT_FETCH_COUNT):
         DEBUG_OUTPUT("Statement::_fetch_generator()", self.handle, self.trans._trans_handle, self.trans.connection.db_handle)
         connection = self.trans.connection
         while rows:
@@ -106,7 +106,7 @@ class Statement(object):
                             r[i] = connection.bytes_to_str(r[i])
                 yield tuple(r)
             if more_data:
-                connection._op_fetch(self.handle, calc_blr(self.xsqlda))
+                connection._op_fetch(self.handle, calc_blr(self.xsqlda), fetch_count)
                 (rows, more_data) = connection._op_fetch_response(self.handle, self.xsqlda)
             else:
                 break
@@ -269,14 +269,28 @@ class Cursor(object):
             (h, oid, buf) = self.transaction.connection._op_response()
 
             if stmt.stmt_type == isc_info_sql_stmt_select:
-                self.transaction.connection._op_fetch(stmt.handle, calc_blr(stmt.xsqlda))
+                fetch_count = self._fetch_count()
+                self.transaction.connection._op_fetch(stmt.handle, calc_blr(stmt.xsqlda), fetch_count)
                 (rows, more_data) = self.transaction.connection._op_fetch_response(stmt.handle, stmt.xsqlda)
-                self._fetch_records = stmt.fetch_generator(rows, more_data)
+                self._fetch_records = stmt.fetch_generator(rows, more_data, fetch_count)
             else:
                 self._fetch_records = None
             self._callproc_result = None
 
         return self
+
+    def _fetch_count(self):
+        """Rows to request per server roundtrip.
+
+        Honour cursor.arraysize (PEP 249) as a hint to reduce roundtrips, but
+        never drop below DEFAULT_FETCH_COUNT so the default arraysize of 1 keeps
+        its historical batching instead of fetching a single row at a time.
+        """
+        try:
+            arraysize = int(self.arraysize)
+        except (TypeError, ValueError):
+            arraysize = 0
+        return max(arraysize, DEFAULT_FETCH_COUNT)
 
     def _is_execute_procedure_query(self):
         """Return True if the current query is EXECUTE PROCEDURE / EXECUTE BLOCK."""

--- a/firebirdsql/wireprotocol.py
+++ b/firebirdsql/wireprotocol.py
@@ -721,13 +721,13 @@ class WireProtocol(object):
         self.sock.send(p.get_buffer())
 
     @wire_operation
-    def _op_fetch(self, stmt_handle, blr):
+    def _op_fetch(self, stmt_handle, blr, fetch_count=DEFAULT_FETCH_COUNT):
         p = Packer()
         p.pack_int(self.op_fetch)
         p.pack_int(stmt_handle)
         p.pack_bytes(blr)
         p.pack_int(0)
-        p.pack_int(400)
+        p.pack_int(fetch_count)
         self.sock.send(p.get_buffer())
 
     @wire_operation

--- a/firebirdsql/wireprotocol.py
+++ b/firebirdsql/wireprotocol.py
@@ -721,7 +721,7 @@ class WireProtocol(object):
         self.sock.send(p.get_buffer())
 
     @wire_operation
-    def _op_fetch(self, stmt_handle, blr, fetch_count=DEFAULT_FETCH_COUNT):
+    def _op_fetch(self, stmt_handle, blr, fetch_count):
         p = Packer()
         p.pack_int(self.op_fetch)
         p.pack_int(stmt_handle)

--- a/sphinx/Python-DB-API-2.0.rst
+++ b/sphinx/Python-DB-API-2.0.rst
@@ -342,7 +342,7 @@ following methods and attributes:
       subclass) exception is raised if the previous call to `executeXXX()`
       did not produce any result set or no call was issued yet.
 
-   .. attaribute arraysize
+   .. attribute:: arraysize
 
       This read/write attribute specifies the number of
       rows to fetch at a time with `fetchmany()`. It defaults to 1 meaning

--- a/sphinx/changelog.rst
+++ b/sphinx/changelog.rst
@@ -354,3 +354,8 @@ Version 1.4.6
 
    - fix aio and many columns bug #132
    - fix execute_immediate bug #133
+
+Version 1.?.?
+==============
+
+   - honour cursor.arraysize as a hint for rows fetched per server roundtrip

--- a/sphinx/python-db-api-compliance.rst
+++ b/sphinx/python-db-api-compliance.rst
@@ -22,9 +22,12 @@ Nominally Supported Optional Features
         .. attribute:: arraysize
 
         As required by the spec, the value of this attribute is observed with
-        respect to the `fetchmany` method. However, changing the value of this
-        attribute does not make any difference in fetch efficiency because
-        the database engine only supports fetching a single row at a time.
+        respect to the `fetchmany` method. In addition, it is used as a hint
+        for how many rows to request from the server per network roundtrip:
+        when a SELECT is executed, the driver fetches ``max(arraysize, 400)``
+        rows at a time. Raising `arraysize` before calling `execute` therefore
+        reduces the number of roundtrips when reading large result sets. The
+        default `arraysize` of 1 keeps the historical batch size of 400 rows.
 
         .. method:: setinputsizes()
 


### PR DESCRIPTION
The amount of batch prefetch has been hardcoded to 400 rows in pyfirebirdsql. This patch preserves this as default and baseline, but allows it to grow if the DB-API array size is specified to be larger than 400.

I have measured throughput improvements of ~50% for queries against large, narrow tables with this change and an array/fetch size of 1024, compared to the previous 400.

In practice the actual amount of prefetched data is limited not just by the client, but by the server-side Firebird setting for TcpRemoteBufferSize. The default is only 8k, so on wider tables this will limit the number of rows before hitting the existing 400 limit. If you combine increased fetch count and increased TcpRemoteBufferSize, you can get very nice speedups as well.